### PR TITLE
fix playerDeath event

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -499,7 +499,7 @@ alt.on('entityLeaveCheckpoint', (cp, entity) => {
   }
 });
 
-alt.on('playerDead', (player, killer, weapon) => {
+alt.on('playerDeath', (player, killer, weapon) => {
   let weaponName = 'Killed';
   if(weapon in weaponHashes)
     weaponName = weaponHashes[weapon];


### PR DESCRIPTION
When a player dies an event is fired which is called playerDeath and not playerDead